### PR TITLE
Fixes #49 - Tag all resources that support tagging.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- tag resources that were not yet applying tags - see [#49](https://github.com/ExpediaInc/apiary-federation/issues/49).
+
 ## [1.0.3] - 2019-01-30
 
 ### Changed

--- a/endpoints.tf
+++ b/endpoints.tf
@@ -75,6 +75,7 @@ resource "aws_route53_zone" "remote_metastore" {
   count  = "${ var.enable_remote_metastore_dns == "" ? 0 : 1 }"
   name   = "${local.remote_metastore_zone_prefix}-${var.aws_region}.${var.domain_extension}"
   vpc_id = "${var.vpc_id}"
+  tags   = "${var.tags}"
 }
 
 resource "aws_route53_record" "metastore_alias" {

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@
 
 resource "aws_ecs_cluster" "waggledance" {
   name = "${local.instance_alias}"
+  tags = "${var.tags}"
 }
 
 resource "aws_iam_role" "waggledance_task_exec" {
@@ -26,6 +27,8 @@ resource "aws_iam_role" "waggledance_task_exec" {
   ]
 }
 EOF
+
+  tags = "${var.tags}"
 }
 
 resource "aws_iam_role_policy_attachment" "task_exec_managed" {
@@ -51,6 +54,8 @@ resource "aws_iam_role" "waggledance_task" {
   ]
 }
 EOF
+
+  tags = "${var.tags}"
 }
 
 resource "aws_iam_role_policy" "secretsmanager_for_waggledance_task" {
@@ -155,6 +160,7 @@ resource "aws_ecs_task_definition" "waggledance" {
   cpu                      = "${var.cpu}"
   requires_compatibilities = ["EC2", "FARGATE"]
   container_definitions    = "${data.template_file.waggledance.rendered}"
+  tags                     = "${var.tags}"
 }
 
 resource "aws_security_group" "wd_sg" {


### PR DESCRIPTION
Fixes #49

Unfortunately, this PR is not applying tags to ECS services, because Terraform doesn't support conditional logic in maps or lists, which we need to do conditional tagging based on whether or not the AWS account has opted-in to the longer ARN format for ECS services.